### PR TITLE
customise className prefix

### DIFF
--- a/.changeset/friendly-zebras-walk.md
+++ b/.changeset/friendly-zebras-walk.md
@@ -1,0 +1,5 @@
+---
+'@utilitywarehouse/web-ui': patch
+---
+
+This change customises the generated className prefix. This is mainly to distinguish Web UI components when migrating from Customer Web UI.

--- a/packages/web-ui/.storybook/preview.js
+++ b/packages/web-ui/.storybook/preview.js
@@ -1,3 +1,8 @@
+import { classNamePrefix } from '../src/utils';
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => componentName.replace('Mui', classNamePrefix));
+
 import '@utilitywarehouse/fontsource';
 import { ThemeProvider } from '../src/ThemeProvider';
 import { breakpoints } from '../src/tokens';

--- a/packages/web-ui/src/Menu/Menu.theme.ts
+++ b/packages/web-ui/src/Menu/Menu.theme.ts
@@ -1,5 +1,5 @@
 import { Components } from '@mui/material/styles';
-import { spacing } from '../utils';
+import { classNamePrefix, spacing } from '../utils';
 import { colors } from '@utilitywarehouse/colour-system';
 
 export const menuThemeOverrides: Components = {
@@ -12,7 +12,7 @@ export const menuThemeOverrides: Components = {
     },
     styleOverrides: {
       root: {
-        '& .MuiPaper-root': {
+        [`& .${classNamePrefix}Paper-root`]: {
           marginTop: spacing(1),
           borderColor: colors.cyan400,
           borderRadius: spacing(1),
@@ -20,7 +20,7 @@ export const menuThemeOverrides: Components = {
           borderWidth: '2px',
           padding: '0',
           boxShadow: 'none',
-          '& .MuiMenu-list': {
+          [`& .${classNamePrefix}Menu-list`]: {
             padding: 0,
           },
         },

--- a/packages/web-ui/src/TextField/TextField.theme.ts
+++ b/packages/web-ui/src/TextField/TextField.theme.ts
@@ -1,7 +1,7 @@
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 import { fonts, fontWeights, transitions } from '../tokens';
 import { Components } from '@mui/material/styles';
-import { dataAttributes, pxToRem, spacing } from '../utils';
+import { classNamePrefix, dataAttributes, pxToRem, spacing } from '../utils';
 
 const { success, multiline } = dataAttributes;
 
@@ -19,13 +19,13 @@ export const textFieldThemeOverrides: Components = {
         lineHeight: 1,
         marginBottom: spacing(1),
         color: colorsCommon.brandMidnight,
-        '&.Mui-focused': {
+        [`&.${classNamePrefix}-focused`]: {
           color: colorsCommon.brandMidnight,
         },
-        '&.Mui-disabled': {
+        [`&.${classNamePrefix}-disabled`]: {
           color: colors.grey700,
         },
-        '&.Mui-error': {
+        [`&.${classNamePrefix}-error`]: {
           color: colorsCommon.brandMidnight,
         },
       },
@@ -41,7 +41,7 @@ export const textFieldThemeOverrides: Components = {
         margin: 0,
         marginTop: spacing(1),
         color: colorsCommon.brandMidnight,
-        '&.Mui-error': {
+        [`&.${classNamePrefix}-error`]: {
           color: colors.red600,
         },
       },
@@ -73,7 +73,7 @@ export const textFieldThemeOverrides: Components = {
         ':hover': {
           backgroundColor: colorsCommon.brandWhite,
           borderBottomColor: colors.cyan600,
-          '&:not(.Mui-disabled)': {
+          [`&:not(.${classNamePrefix}-disabled)`]: {
             '&:before': {
               borderWidth: 2,
               transition: `border ${transitions.duration}ms ${transitions.easingFunction}`,
@@ -91,11 +91,11 @@ export const textFieldThemeOverrides: Components = {
           borderWidth: 2,
           transition: `border ${transitions.duration}ms ${transitions.easingFunction}`,
         },
-        '&.Mui-focused': {
+        [`&.${classNamePrefix}-focused`]: {
           backgroundColor: colorsCommon.brandWhite,
           borderColor: colors.cyan600,
         },
-        '&.Mui-disabled': {
+        [`&.${classNamePrefix}-disabled`]: {
           color: colorsCommon.brandMidnight,
           backgroundColor: colors.grey50,
           borderColor: colors.grey100,
@@ -109,11 +109,11 @@ export const textFieldThemeOverrides: Components = {
             borderColor: colors.grey600,
           },
         },
-        '&.Mui-error': {
-          '&.Mui-focused': {
+        [`&.${classNamePrefix}-error`]: {
+          [`&.${classNamePrefix}-focused`]: {
             borderColor: colors.red600,
           },
-          '&:not(.Mui-disabled)': {
+          [`&:not(.${classNamePrefix}-disabled)`]: {
             '&:after': {
               borderColor: colors.red600,
             },
@@ -127,16 +127,16 @@ export const textFieldThemeOverrides: Components = {
             borderBottomColor: colors.green600,
           },
           ':hover': {
-            '&:not(.Mui-disabled)': {
+            [`&:not(.${classNamePrefix}-disabled)`]: {
               '&:before': {
                 borderColor: colors.green600,
               },
             },
           },
-          '&.Mui-focused': {
+          [`&.${classNamePrefix}-focused`]: {
             borderColor: colors.green600,
           },
-          '&:not(.Mui-disabled)': {
+          [`&:not(.${classNamePrefix}-disabled)`]: {
             borderBottomColor: colors.green600,
           },
         },

--- a/packages/web-ui/src/TextLink/TextLink.theme.ts
+++ b/packages/web-ui/src/TextLink/TextLink.theme.ts
@@ -1,7 +1,7 @@
 import { Components } from '@mui/material/styles';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 import { transitions } from '../tokens';
-import { dataAttributes } from '../utils';
+import { classNamePrefix, dataAttributes } from '../utils';
 
 const { inverse, bgcolorBrand, heading } = dataAttributes;
 
@@ -31,7 +31,7 @@ export const textLinkThemeOverrides: Partial<Components> = {
         [`[data-${inverse}=true] &`]: {
           color: colorsCommon.brandWhite,
         },
-        '&.MuiTypography-inherit': {
+        [`&.${classNamePrefix}Typography-inherit`]: {
           color: 'inherit',
           textTransform: 'inherit',
         },

--- a/packages/web-ui/src/index.ts
+++ b/packages/web-ui/src/index.ts
@@ -1,3 +1,7 @@
+import { classNamePrefix } from './utils';
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => componentName.replace('Mui', classNamePrefix));
 import './types/overrides';
 
 export * from './theme';

--- a/packages/web-ui/src/utils/index.ts
+++ b/packages/web-ui/src/utils/index.ts
@@ -2,4 +2,4 @@ export { dataAttributes } from './data-attributes';
 export { htmlFontSize, pxToRem, isHeadingVariant } from './typography';
 export { mediaQueries } from './media-queries';
 export { isInverseBackgroundColor } from './color';
-export { px, spacing } from './utils';
+export { px, spacing, classNamePrefix } from './utils';

--- a/packages/web-ui/src/utils/utils.ts
+++ b/packages/web-ui/src/utils/utils.ts
@@ -3,3 +3,5 @@ import { spacingBase } from '../tokens';
 export const px = (value: string | number): string => `${value}px`;
 
 export const spacing = (multiplier: number) => multiplier * spacingBase;
+
+export const classNamePrefix = 'web-ui-';


### PR DESCRIPTION
This change customises the generated className prefix. This is mainly to distinguish Web UI components when migrating from Customer Web UI.