### PR TITLE
Partially reinstate contextual colours

### DIFF
--- a/.changeset/real-wasps-train.md
+++ b/.changeset/real-wasps-train.md
@@ -1,0 +1,10 @@
+---
+'@utilitywarehouse/web-ui': patch
+---
+
+This reinstates the contextual colours for the following components, when wrapped in a `Box` with `backgroundColor` set to either `colorsCommon.brandPrimaryPurple` or `colorsCommon.brandMidnight`:
+
+- `Text`
+- `Heading`
+- `Button`
+- `TextLink`

--- a/packages/web-ui/src/Box/Box.stories.tsx
+++ b/packages/web-ui/src/Box/Box.stories.tsx
@@ -3,6 +3,7 @@ import { Box, BoxProps } from './Box';
 import { useRef } from 'react';
 import { fonts } from '../tokens';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
+import { Text } from '../Text';
 
 const meta: Meta<typeof Box> = {
   title: 'Web UI / Components / Box',
@@ -13,8 +14,12 @@ export default meta;
 type Story = StoryObj<typeof Box>;
 
 export const Workshop: Story = {
-  render: args => {
-    return <Box {...args} />;
+  render: ({ children, ...args }) => {
+    return (
+      <Box {...args}>
+        <Text>{children}</Text>
+      </Box>
+    );
   },
   args: {
     component: 'div',

--- a/packages/web-ui/src/Box/Box.tsx
+++ b/packages/web-ui/src/Box/Box.tsx
@@ -3,10 +3,20 @@ import { OverridableComponent, OverrideProps } from '@mui/material/OverridableCo
 import { forwardRef } from 'react';
 import type { Theme } from '../theme';
 import MuiBox from '@mui/material/Box';
+import { dataAttributes } from '../utils';
+import { colorsCommon } from '@utilitywarehouse/colour-system';
 
 export type DefaultBoxComponent = 'div';
 
-export interface CustomBoxProps {}
+export interface CustomBoxProps {
+  /**
+   * Sets the background colour.
+   *
+   * When 'purple' and 'midnight' brand colours are used, child `Text` &
+   * `Heading` components have their foreground colour set to 'white'.
+   */
+  backgroundColor?: string; // we are not setting this as MuiBoxProps['backgroundColor'] as we don't believe there is any need for it to be responsive, yet.
+}
 
 export type BoxProps<
   D extends React.ElementType<any> = DefaultBoxComponent,
@@ -17,6 +27,14 @@ export type BoxProps<
  * Box is a low-level primitive, which supports theme-aware styling props, and can
  * be used for building any styled element.
  */
-export const Box = forwardRef(function Box(props, ref) {
-  return <MuiBox ref={ref} {...props} />;
+export const Box = forwardRef(function Box({ backgroundColor, bgcolor, ...props }, ref) {
+  const dataAttributeProps =
+    !!backgroundColor &&
+    [colorsCommon.brandMidnight, colorsCommon.brandPrimaryPurple].includes(backgroundColor)
+      ? { [`data-${dataAttributes.bgcolorBrand}`]: true }
+      : {};
+
+  const bg = bgcolor || backgroundColor;
+
+  return <MuiBox ref={ref} {...dataAttributeProps} bgcolor={bg} {...props} />;
 }) as OverridableComponent<MuiBoxTypeMap<CustomBoxProps, DefaultBoxComponent, Theme>>;

--- a/packages/web-ui/src/Button/Button.docs.mdx
+++ b/packages/web-ui/src/Button/Button.docs.mdx
@@ -51,6 +51,15 @@ The tertiary Button has only one size and is not affected by the `size` prop.
   }}
 />
 
+## Contextual color
+
+When inside a `Box` component that specifies a `backgroundColor` which is the
+value of either `colorsCommon.brandMidnight` or
+`colorsCommon.brandPrimaryPurple`, the `Button` colors will be slightly different.
+
+This is also the case when rendered inside the deprecated `Background`
+component with a `backgroundColor` of either `purple` or `midnight`.
+
 ## Capitalization
 
 By default Button will render the label with only the first word capitalized. If you need to render text with different capitalization you can first set the `disableCapitalizeFirstLetter` prop to `true`.

--- a/packages/web-ui/src/Button/Button.stories.tsx
+++ b/packages/web-ui/src/Button/Button.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { colorsCommon } from '@utilitywarehouse/colour-system';
+import { Box } from '../Box';
 import { Stack } from '../Stack';
 import { Backgrounds } from '../storybook-utils';
 import { Button } from './Button';
@@ -25,32 +27,38 @@ export const ButtonKitchenSink: Story = {
   },
   render: () => {
     return (
-      <Backgrounds>
-        <Stack spacing={4}>
-          {variants.map(variant => (
-            <Stack key={variant} direction="row" spacing={2} alignItems="center">
-              <>
-                {sizes.map(size => (
-                  <Button key={size} size={size} variant={variant}>
+      <Stack>
+        {[colorsCommon.brandWhite, colorsCommon.brandPrimaryPurple, colorsCommon.brandMidnight].map(
+          bg => (
+            <Box key={bg} backgroundColor={bg} display="flex" justifyContent="center" padding={4}>
+              <Stack spacing={4}>
+                {variants.map(variant => (
+                  <Stack key={variant} direction="row" spacing={2} alignItems="center">
+                    <>
+                      {sizes.map(size => (
+                        <Button key={size} size={size} variant={variant}>
+                          button
+                        </Button>
+                      ))}
+                      {sizes.map(size => (
+                        <Button key={size} size={size} variant={variant} disabled={true}>
+                          button
+                        </Button>
+                      ))}
+                    </>
+                  </Stack>
+                ))}
+                <Stack direction="row" spacing={2} alignItems="center">
+                  <Button variant="tertiary">button</Button>
+                  <Button variant="tertiary" disabled={true}>
                     button
                   </Button>
-                ))}
-                {sizes.map(size => (
-                  <Button key={size} size={size} variant={variant} disabled={true}>
-                    button
-                  </Button>
-                ))}
-              </>
-            </Stack>
-          ))}
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Button variant="tertiary">button</Button>
-            <Button variant="tertiary" disabled={true}>
-              button
-            </Button>
-          </Stack>
-        </Stack>
-      </Backgrounds>
+                </Stack>
+              </Stack>
+            </Box>
+          )
+        )}
+      </Stack>
     );
   },
 };
@@ -127,6 +135,47 @@ export const ButtonSizes: Story = {
         <Button size="medium">medium</Button>
         <Button size="large">large</Button>
       </Stack>
+    );
+  },
+};
+
+export const ButtonLegacyColour: Story = {
+  name: 'On legacy Background component',
+  parameters: {
+    layout: 'fullscreen',
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/4FFYTLWJ2hQpj36JplQQUw/UW-Web-UI---MASTER?node-id=6%3A139&t=nzEeo2X7lGLW2Y93-1',
+    },
+  },
+  render: () => {
+    return (
+      <Backgrounds>
+        <Stack spacing={4}>
+          {variants.map(variant => (
+            <Stack key={variant} direction="row" spacing={2} alignItems="center">
+              <>
+                {sizes.map(size => (
+                  <Button key={size} size={size} variant={variant}>
+                    button
+                  </Button>
+                ))}
+                {sizes.map(size => (
+                  <Button key={size} size={size} variant={variant} disabled={true}>
+                    button
+                  </Button>
+                ))}
+              </>
+            </Stack>
+          ))}
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Button variant="tertiary">button</Button>
+            <Button variant="tertiary" disabled={true}>
+              button
+            </Button>
+          </Stack>
+        </Stack>
+      </Backgrounds>
     );
   },
 };

--- a/packages/web-ui/src/Button/Button.stories.tsx
+++ b/packages/web-ui/src/Button/Button.stories.tsx
@@ -140,7 +140,7 @@ export const ButtonSizes: Story = {
 };
 
 export const ButtonLegacyColour: Story = {
-  name: 'On legacy Background component',
+  name: 'On legacy Background',
   parameters: {
     layout: 'fullscreen',
     design: {

--- a/packages/web-ui/src/Button/Button.theme.ts
+++ b/packages/web-ui/src/Button/Button.theme.ts
@@ -4,7 +4,7 @@ import { fonts, fontWeights, transitions } from '../tokens';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 
 const borderWidth = 2;
-const { disableCapitalizeFirstLetter, inverse, size, variant } = dataAttributes;
+const { disableCapitalizeFirstLetter, inverse, bgcolorBrand, size, variant } = dataAttributes;
 
 export const buttonThemeOverrides: Partial<Components> = {
   MuiButton: {
@@ -40,6 +40,12 @@ export const buttonThemeOverrides: Partial<Components> = {
         [`&[data-${disableCapitalizeFirstLetter}=true]::first-letter`]: {
           textTransform: 'none',
         },
+        [`[data-${bgcolorBrand}=true] &`]: {
+          '&:disabled': {
+            opacity: 0.6,
+          },
+        },
+        // TODO: remove when `Background` removed.
         [`[data-${inverse}=true] &`]: {
           '&:disabled': {
             opacity: 0.6,
@@ -77,6 +83,13 @@ export const buttonThemeOverrides: Partial<Components> = {
             opacity: 0.5,
             borderWidth,
           },
+          [`[data-${bgcolorBrand}=true] &`]: {
+            color: colorsCommon.brandWhite,
+            '&:hover': {
+              borderColor: colorsCommon.brandWhite,
+            },
+          },
+          // TODO: remove when `Background` removed.
           [`[data-${inverse}=true] &`]: {
             color: colorsCommon.brandWhite,
             '&:hover': {
@@ -99,6 +112,10 @@ export const buttonThemeOverrides: Partial<Components> = {
           '&:hover': {
             opacity: 0.5,
           },
+          [`[data-${bgcolorBrand}=true] &`]: {
+            color: colorsCommon.brandWhite,
+          },
+          // TODO: remove when `Background` removed.
           [`[data-${inverse}=true] &`]: {
             color: colorsCommon.brandWhite,
           },

--- a/packages/web-ui/src/Heading/Heading.docs.mdx
+++ b/packages/web-ui/src/Heading/Heading.docs.mdx
@@ -7,13 +7,9 @@ import * as Stories from './Heading.stories';
 
 <Description />
 
-## Variants
+## Sizes
 
-<Canvas of={Stories.HeadingVariants} />
-
-## Semantic HTML
-
-The `component` prop is required for this component, encouraging you to consider the correct semantic element.
+<Canvas of={Stories.HeadingSizes} />
 
 ## Color
 

--- a/packages/web-ui/src/Heading/Heading.docs.mdx
+++ b/packages/web-ui/src/Heading/Heading.docs.mdx
@@ -24,6 +24,15 @@ import { colorsCommon } from '@utilitywarehouse/colour-system'
 <Heading color={colorsCommon.brandMidnight}>{...}</Heading>
 ```
 
+### Contextual colour
+
+When inside a `Box` component that specifies a `backgroundColor` which is the
+value of either `colorsCommon.brandMidnight` or
+`colorsCommon.brandPrimaryPurple`, the `Heading` color will be set to
+`colorsCommon.brandWhite`. This will be overridden by the `color` prop.
+
+<Canvas of={Stories.HeadingColour} />
+
 ## Styles
 
 The system props are not available on the Heading component, if you need custom typography then use the [Typography](?path=/docs/components-typography--documentation) component.

--- a/packages/web-ui/src/Heading/Heading.docs.mdx
+++ b/packages/web-ui/src/Heading/Heading.docs.mdx
@@ -7,9 +7,9 @@ import * as Stories from './Heading.stories';
 
 <Description />
 
-## Sizes
+## Variants
 
-<Canvas of={Stories.HeadingSizes} />
+<Canvas of={Stories.HeadingVariants} />
 
 ## Color
 

--- a/packages/web-ui/src/Heading/Heading.stories.tsx
+++ b/packages/web-ui/src/Heading/Heading.stories.tsx
@@ -11,15 +11,15 @@ const meta: Meta<typeof Heading> = {
 export default meta;
 type Story = StoryObj<typeof Heading>;
 
-const sizes = ['xl', 'lg', 'md', 'sm', 'xs'] as const;
+const variants = ['displayHeading', 'h1', 'h2', 'h3', 'h4'] as const;
 
 export const KitchenSink: Story = {
   render: () => {
     return (
       <Stack spacing={1}>
-        {sizes.map(size => (
-          <Heading key={size} size={size}>
-            Heading size {size}
+        {variants.map(variant => (
+          <Heading key={variant} variant={variant}>
+            Heading variant: {variant}
           </Heading>
         ))}
       </Stack>
@@ -48,8 +48,8 @@ export const Workshop: Story = {
         type: 'text',
       },
     },
-    size: {
-      options: sizes,
+    variant: {
+      options: variants,
       control: {
         type: 'radio',
       },
@@ -69,24 +69,25 @@ export const Workshop: Story = {
   },
   args: {
     children: 'hamburgefons',
-    size: 'md',
+    variant: 'h2',
     component: 'h2',
     color: undefined,
     textTransform: 'capitalize',
-    noWrap: false,
   },
 };
 
-export const HeadingSizes: Story = {
-  name: 'Sizes',
+export const HeadingVariants: Story = {
+  name: 'Variants',
   render: () => {
     return (
       <Stack spacing={1}>
-        <Heading size="xl">hamburgefons (xl)</Heading>
-        <Heading size="lg">hamburgefons (lg)</Heading>
-        <Heading size="md">hamburgefons (md)</Heading>
-        <Heading size="sm">hamburgefons (sm)</Heading>
-        <Heading size="xs">hamburgefons (xs)</Heading>
+        <Heading variant="displayHeading" noWrap>
+          hamburgefons (displayHeading)
+        </Heading>
+        <Heading variant="h1">hamburgefons (h1)</Heading>
+        <Heading variant="h2">hamburgefons (h2)</Heading>
+        <Heading variant="h3">hamburgefons (h3)</Heading>
+        <Heading variant="h4">hamburgefons (h4)</Heading>
       </Stack>
     );
   },

--- a/packages/web-ui/src/Heading/Heading.stories.tsx
+++ b/packages/web-ui/src/Heading/Heading.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Stack from '@mui/material/Stack';
-import { Heading, HeadingProps } from './Heading';
+import { Heading } from './Heading';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 
 const meta: Meta<typeof Heading> = {

--- a/packages/web-ui/src/Heading/Heading.stories.tsx
+++ b/packages/web-ui/src/Heading/Heading.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Stack from '@mui/material/Stack';
 import { Heading } from './Heading';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
+import { Box } from '../Box';
 
 const meta: Meta<typeof Heading> = {
   title: 'Web UI / Components / Heading',
@@ -88,6 +89,30 @@ export const HeadingVariants: Story = {
         <Heading variant="h2">hamburgefons (h2)</Heading>
         <Heading variant="h3">hamburgefons (h3)</Heading>
         <Heading variant="h4">hamburgefons (h4)</Heading>
+      </Stack>
+    );
+  },
+};
+
+export const HeadingColour: Story = {
+  name: 'Contextual Colour',
+  render: () => {
+    return (
+      <Stack>
+        <Box padding={2}>
+          <Heading variant="h2">heading</Heading>
+        </Box>
+        <Box padding={2} backgroundColor={colorsCommon.brandPrimaryPurple}>
+          <Heading variant="h2">heading on brandPrimaryPurple background</Heading>
+        </Box>
+        <Box padding={2} backgroundColor={colorsCommon.brandMidnight}>
+          <Heading variant="h2">heading on brandMidnight background</Heading>
+        </Box>
+        <Box padding={2} backgroundColor={colorsCommon.brandMidnight}>
+          <Heading variant="h2" color={colorsCommon.brandPink}>
+            heading on brandMidnight background with custom color
+          </Heading>
+        </Box>
       </Stack>
     );
   },

--- a/packages/web-ui/src/Heading/Heading.stories.tsx
+++ b/packages/web-ui/src/Heading/Heading.stories.tsx
@@ -1,9 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Stack from '@mui/material/Stack';
-import { Heading, HeadingProps, headingVariantMapping } from './Heading';
+import { Heading, HeadingProps } from './Heading';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
-
-const variants = Object.keys(headingVariantMapping);
 
 const meta: Meta<typeof Heading> = {
   title: 'Web UI / Components / Heading',
@@ -13,17 +11,15 @@ const meta: Meta<typeof Heading> = {
 export default meta;
 type Story = StoryObj<typeof Heading>;
 
+const sizes = ['xl', 'lg', 'md', 'sm', 'xs'] as const;
+
 export const KitchenSink: Story = {
   render: () => {
     return (
       <Stack spacing={4}>
-        {variants.map(v => (
-          <Heading
-            key={v}
-            variant={v as HeadingProps['variant']}
-            component={headingVariantMapping[v] as React.ElementType<any>}
-          >
-            Hamburgefons
+        {sizes.map(size => (
+          <Heading key={size} size={size}>
+            Heading size {size}
           </Heading>
         ))}
       </Stack>
@@ -52,8 +48,8 @@ export const Workshop: Story = {
         type: 'text',
       },
     },
-    variant: {
-      options: variants,
+    size: {
+      options: sizes,
       control: {
         type: 'radio',
       },
@@ -73,36 +69,24 @@ export const Workshop: Story = {
   },
   args: {
     children: 'hamburgefons',
-    variant: 'h2',
+    size: 'md',
     component: 'h2',
     color: undefined,
     textTransform: 'capitalize',
-    gutterBottom: false,
-    paragraph: false,
     noWrap: false,
   },
 };
 
 export const HeadingVariants: Story = {
-  name: 'Variants',
+  name: 'Sizes',
   render: () => {
     return (
       <Stack spacing={1}>
-        <Heading component="h1" variant="displayHeading">
-          displayHeading
-        </Heading>
-        <Heading component="h1" variant="h1">
-          h1
-        </Heading>
-        <Heading component="h2" variant="h2">
-          h2
-        </Heading>
-        <Heading component="h3" variant="h3">
-          h3
-        </Heading>
-        <Heading component="h4" variant="h4">
-          h4
-        </Heading>
+        <Heading size="xl">hamburgefons (xl)</Heading>
+        <Heading size="lg">hamburgefons (lg)</Heading>
+        <Heading size="md">hamburgefons (md)</Heading>
+        <Heading size="sm">hamburgefons (sm)</Heading>
+        <Heading size="xs">hamburgefons (xs)</Heading>
       </Stack>
     );
   },

--- a/packages/web-ui/src/Heading/Heading.stories.tsx
+++ b/packages/web-ui/src/Heading/Heading.stories.tsx
@@ -16,7 +16,7 @@ const sizes = ['xl', 'lg', 'md', 'sm', 'xs'] as const;
 export const KitchenSink: Story = {
   render: () => {
     return (
-      <Stack spacing={4}>
+      <Stack spacing={1}>
         {sizes.map(size => (
           <Heading key={size} size={size}>
             Heading size {size}

--- a/packages/web-ui/src/Heading/Heading.stories.tsx
+++ b/packages/web-ui/src/Heading/Heading.stories.tsx
@@ -77,7 +77,7 @@ export const Workshop: Story = {
   },
 };
 
-export const HeadingVariants: Story = {
+export const HeadingSizes: Story = {
   name: 'Sizes',
   render: () => {
     return (

--- a/packages/web-ui/src/Heading/Heading.tsx
+++ b/packages/web-ui/src/Heading/Heading.tsx
@@ -4,19 +4,20 @@ import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { fonts, fontWeights } from '../tokens';
 import { pxToRem } from '../utils';
 
-export type HeadingProps = Pick<BoxProps, 'sx' | 'component' | 'children'> &
-  Pick<MuiTypographyProps, 'textTransform' | 'align' | 'noWrap'> & {
-    /**
-     * Applies the typography size styles.
-     * @default md
-     */
-    size?: 'xl' | 'lg' | 'md' | 'sm' | 'xs';
-    /**
-     * Set the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
-     * @default colorsCommon.brandPrimaryPurple
-     */
-    color?: string;
-  };
+export type HeadingProps = {
+  /**
+   * Applies the heading font styles.
+   * @default h2
+   */
+  variant?: 'displayHeading' | 'h1' | 'h2' | 'h3' | 'h4';
+  /**
+   * Sets the heading color.
+   * It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
+   * @default colorsCommon.brandPrimaryPurple
+   */
+  color?: string;
+} & Pick<BoxProps, 'sx' | 'component' | 'children'> &
+  Pick<MuiTypographyProps, 'textTransform' | 'align' | 'noWrap'>;
 
 /**
  * Heading renders the primary UW font, to be used for heading-level typography.
@@ -24,7 +25,7 @@ export type HeadingProps = Pick<BoxProps, 'sx' | 'component' | 'children'> &
 export const Heading = ({
   color = colorsCommon.brandPrimaryPurple,
   component = 'h2',
-  size = 'md',
+  variant = 'h2',
   align,
   noWrap,
   sx,
@@ -33,36 +34,36 @@ export const Heading = ({
   const fontFamily = fonts.primary;
   const fontWeight = fontWeights.primary;
   const fontSizes = {
-    xs: {
+    h4: {
       mobile: pxToRem(18),
       desktop: pxToRem(20),
     },
-    sm: {
+    h3: {
       mobile: pxToRem(22),
       desktop: pxToRem(24),
     },
-    md: {
+    h2: {
       mobile: pxToRem(28),
       desktop: pxToRem(32),
     },
-    lg: {
+    h1: {
       mobile: pxToRem(32),
       desktop: pxToRem(42),
     },
-    xl: {
+    displayHeading: {
       mobile: pxToRem(42),
       desktop: pxToRem(64),
     },
   };
   const lineHeights = {
-    xs: 1.5,
-    sm: 1.5,
-    md: {
+    h4: 1.5,
+    h3: 1.5,
+    h2: {
       mobile: 1.2,
       desktop: 1.5,
     },
-    lg: 1.2,
-    xl: 1,
+    h1: 1.2,
+    displayHeading: 1.2,
   };
 
   const noWrapStyles = {
@@ -77,9 +78,9 @@ export const Heading = ({
       color={color}
       component={component}
       fontFamily={fontFamily}
-      fontSize={fontSizes[size]}
+      fontSize={fontSizes[variant]}
       fontWeight={fontWeight}
-      lineHeight={lineHeights[size]}
+      lineHeight={lineHeights[variant]}
       textAlign={align}
       sx={noWrap ? noWrapStyles : sx}
       {...props}

--- a/packages/web-ui/src/Heading/Heading.tsx
+++ b/packages/web-ui/src/Heading/Heading.tsx
@@ -3,59 +3,92 @@ import MuiTypography, { TypographyProps as MuiTypographyProps } from '@mui/mater
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import type { OverrideProps } from '@mui/material/OverridableComponent';
 import type { SystemProps } from '../types';
+import { Box, BoxProps } from '../Box';
+import { colorsCommon } from '@utilitywarehouse/colour-system';
+import { fonts, fontWeights } from '../tokens';
+import { pxToRem } from '../utils';
 
-export type DefaultHeadingComponent = 'h2';
-
-export const headingVariantMapping: Record<string, string> = {
-  displayHeading: 'h1',
-  h1: 'h1',
-  h2: 'h2',
-  h3: 'h3',
-  h4: 'h4',
-};
-
-export interface CustomHeadingProps {
-  /**
-   * Applies the theme typography styles.
-   * @default h2
-   */
-  variant: 'displayHeading' | 'h1' | 'h2' | 'h3' | 'h4';
-  /**
-   * The component used for the root node. Either a string to use a HTML element or a component.
-   */
-  component: React.ElementType;
-  /**
-   * Set the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
-   * @default colorsCommon.brandPrimaryPurple
-   */
-  color?: string;
-  /**
-   * Set the text-transform property on the component.
-   */
-  textTransform?: MuiTypographyProps['textTransform'];
-}
-
-export interface HeadingTypeMap<D extends React.ElementType = DefaultHeadingComponent, P = {}> {
-  props: CustomHeadingProps & Omit<MuiTypographyProps<D, P>, 'variant' | SystemProps>;
-  defaultComponent: D;
-}
-
-export type HeadingProps<
-  D extends React.ElementType = DefaultHeadingComponent,
-  P = {}
-> = OverrideProps<HeadingTypeMap<D, P>, D>;
+export type HeadingProps = Pick<BoxProps, 'sx' | 'component' | 'children'> &
+  Pick<MuiTypographyProps, 'textTransform' | 'align' | 'noWrap'> & {
+    /**
+     * Applies the typography size styles.
+     * @default md
+     */
+    size?: 'xl' | 'lg' | 'md' | 'sm' | 'xs';
+    /**
+     * Set the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
+     * @default colorsCommon.brandPrimaryPurple
+     */
+    color?: string;
+  };
 
 /**
  * Heading renders the primary UW font, to be used for heading-level typography.
  */
-export const Heading = forwardRef(function Heading({ color, variant = 'h2', ...props }, ref) {
+export const Heading = ({
+  color = colorsCommon.brandPrimaryPurple,
+  component = 'h2',
+  size = 'md',
+  align,
+  noWrap,
+  sx,
+  ...props
+}: HeadingProps) => {
+  const fontFamily = fonts.primary;
+  const fontWeight = fontWeights.primary;
+  const fontSizes = {
+    xs: {
+      mobile: pxToRem(18),
+      desktop: pxToRem(20),
+    },
+    sm: {
+      mobile: pxToRem(22),
+      desktop: pxToRem(24),
+    },
+    md: {
+      mobile: pxToRem(28),
+      desktop: pxToRem(32),
+    },
+    lg: {
+      mobile: pxToRem(32),
+      desktop: pxToRem(42),
+    },
+    xl: {
+      mobile: pxToRem(42),
+      desktop: pxToRem(64),
+    },
+  };
+  const lineHeights = {
+    xs: 1.5,
+    sm: 1.5,
+    md: {
+      mobile: 1.2,
+      desktop: 1.5,
+    },
+    lg: 1.2,
+    xl: 1,
+  };
+
+  const noWrapStyles = {
+    ...sx,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+
   return (
-    <MuiTypography
-      ref={ref}
-      variantMapping={headingVariantMapping}
-      variant={variant}
+    <Box
       color={color}
+      component={component}
+      fontFamily={fontFamily}
+      fontSize={fontSizes[size]}
+      fontWeight={fontWeight}
+      lineHeight={lineHeights[size]}
+      textAlign={align}
+      sx={noWrap ? noWrapStyles : sx}
       {...props}
     />
   );
-}) as OverridableComponent<HeadingTypeMap>;
+};
+
+Heading.displayName = 'Heading';

--- a/packages/web-ui/src/Heading/Heading.tsx
+++ b/packages/web-ui/src/Heading/Heading.tsx
@@ -2,7 +2,7 @@ import { TypographyProps as MuiTypographyProps } from '@mui/material/Typography'
 import { Box, BoxProps } from '../Box';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { fonts, fontWeights } from '../tokens';
-import { pxToRem } from '../utils';
+import { dataAttributes, pxToRem } from '../utils';
 
 export type HeadingProps = {
   /**
@@ -23,7 +23,7 @@ export type HeadingProps = {
  * Heading renders the primary UW font, to be used for heading-level typography.
  */
 export const Heading = ({
-  color = colorsCommon.brandPrimaryPurple,
+  color,
   component = 'h2',
   variant = 'h2',
   align,
@@ -66,8 +66,19 @@ export const Heading = ({
     displayHeading: 1.2,
   };
 
-  const noWrapStyles = {
+  const colorStyles = {
+    [`[data-${dataAttributes.bgcolorBrand}=true] &`]: {
+      color: color || colorsCommon.brandWhite,
+    },
+  };
+
+  const baseStyles = {
     ...sx,
+    ...colorStyles,
+  };
+
+  const noWrapStyles = {
+    ...baseStyles,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -75,14 +86,14 @@ export const Heading = ({
 
   return (
     <Box
-      color={color}
+      color={color || colorsCommon.brandPrimaryPurple}
       component={component}
       fontFamily={fontFamily}
       fontSize={fontSizes[variant]}
       fontWeight={fontWeight}
       lineHeight={lineHeights[variant]}
       textAlign={align}
-      sx={noWrap ? noWrapStyles : sx}
+      sx={noWrap ? noWrapStyles : baseStyles}
       {...props}
     />
   );

--- a/packages/web-ui/src/Heading/Heading.tsx
+++ b/packages/web-ui/src/Heading/Heading.tsx
@@ -1,8 +1,4 @@
-import { forwardRef } from 'react';
-import MuiTypography, { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
-import { OverridableComponent } from '@mui/material/OverridableComponent';
-import type { OverrideProps } from '@mui/material/OverridableComponent';
-import type { SystemProps } from '../types';
+import { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
 import { Box, BoxProps } from '../Box';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { fonts, fontWeights } from '../tokens';

--- a/packages/web-ui/src/Heading/index.ts
+++ b/packages/web-ui/src/Heading/index.ts
@@ -1,7 +1,2 @@
-export { Heading, headingVariantMapping } from './Heading';
-export type {
-  DefaultHeadingComponent,
-  CustomHeadingProps,
-  HeadingTypeMap,
-  HeadingProps,
-} from './Heading';
+export { Heading } from './Heading';
+export type { HeadingProps } from './Heading';

--- a/packages/web-ui/src/Menu/MenuItem.tsx
+++ b/packages/web-ui/src/Menu/MenuItem.tsx
@@ -19,7 +19,7 @@ export type MenuItemProps<
 export const MenuItem = forwardRef(function MenuItem({ children, ...props }, ref) {
   return (
     <MuiMenuItem ref={ref} {...props}>
-      <Text size="md">{children}</Text>
+      <Text variant="body">{children}</Text>
     </MuiMenuItem>
   );
 }) as OverridableComponent<MenuItemTypeMap>;

--- a/packages/web-ui/src/Menu/MenuItem.tsx
+++ b/packages/web-ui/src/Menu/MenuItem.tsx
@@ -19,9 +19,7 @@ export type MenuItemProps<
 export const MenuItem = forwardRef(function MenuItem({ children, ...props }, ref) {
   return (
     <MuiMenuItem ref={ref} {...props}>
-      <Text component="span" variant="body">
-        {children}
-      </Text>
+      <Text size="md">{children}</Text>
     </MuiMenuItem>
   );
 }) as OverridableComponent<MenuItemTypeMap>;

--- a/packages/web-ui/src/Text/Text.docs.mdx
+++ b/packages/web-ui/src/Text/Text.docs.mdx
@@ -7,13 +7,9 @@ import * as Stories from './Text.stories';
 
 <Description />
 
-## Variants
+## Sizes
 
-<Canvas of={Stories.TextVariants} />
-
-## Semantic HTML
-
-The `component` prop is required for this component, encouraging you to consider the correct semantic element.
+<Canvas of={Stories.TextSizes} />
 
 ## Color
 

--- a/packages/web-ui/src/Text/Text.docs.mdx
+++ b/packages/web-ui/src/Text/Text.docs.mdx
@@ -7,9 +7,9 @@ import * as Stories from './Text.stories';
 
 <Description />
 
-## Sizes
+## Variants
 
-<Canvas of={Stories.TextSizes} />
+<Canvas of={Stories.TextVariants} />
 
 ## Color
 

--- a/packages/web-ui/src/Text/Text.docs.mdx
+++ b/packages/web-ui/src/Text/Text.docs.mdx
@@ -11,7 +11,7 @@ import * as Stories from './Text.stories';
 
 <Canvas of={Stories.TextVariants} />
 
-## Color
+## Colour
 
 You can pass any valid string color to the `Text` component. It is recommended
 you use the `@utilitywarehouse/colour-system` package, and pass color values
@@ -23,6 +23,15 @@ import { colorsCommon } from '@utilitywarehouse/colour-system'
 
 <Text color={colorsCommon.brandPrimaryPurple}>{...}</Text>
 ```
+
+### Contextual colour
+
+When inside a `Box` component that specifies a `backgroundColor` which is the
+value of either `colorsCommon.brandMidnight` or
+`colorsCommon.brandPrimaryPurple`, the `Text` color will be set to
+`colorsCommon.brandWhite`. This will be overridden by the `color` prop.
+
+<Canvas of={Stories.TextColour} />
 
 ## Styles
 

--- a/packages/web-ui/src/Text/Text.stories.tsx
+++ b/packages/web-ui/src/Text/Text.stories.tsx
@@ -11,16 +11,16 @@ const meta: Meta<typeof Text> = {
 export default meta;
 type Story = StoryObj<typeof Text>;
 
-const sizes = ['lg', 'md', 'sm', 'xs'] as const;
+const variants = ['subtitle', 'body', 'legalNote', 'caption'] as const;
 
 export const KitchenSink: Story = {
   parameters: { controls: { hideNoControlsWarning: true } },
   render: () => {
     return (
       <Stack spacing={1}>
-        {sizes.map(size => (
-          <Text key={size} size={size}>
-            Text size {size}
+        {variants.map(variant => (
+          <Text key={variant} variant={variant}>
+            Text variant {variant}
           </Text>
         ))}
       </Stack>
@@ -49,8 +49,8 @@ export const Workshop: Story = {
         type: 'text',
       },
     },
-    size: {
-      options: sizes,
+    variant: {
+      options: variants,
       control: {
         type: 'radio',
       },
@@ -73,23 +73,23 @@ export const Workshop: Story = {
   },
   args: {
     children: 'hamburgefons',
-    size: 'md',
-    component: 'span',
+    variant: 'body',
+    component: 'p',
     color: undefined,
     bold: false,
     textTransform: 'capitalize',
   },
 };
 
-export const TextSizes: Story = {
-  name: 'Sizes',
+export const TextVariants: Story = {
+  name: 'Variants',
   render: () => {
     return (
       <Stack spacing={1}>
-        <Text size="lg">hamburgefons (lg)</Text>
-        <Text size="md">hamburgefons (md)</Text>
-        <Text size="sm">hamburgefons (sm)</Text>
-        <Text size="xs">hamburgefons (xs)</Text>
+        <Text variant="subtitle">hamburgefons (subtitle)</Text>
+        <Text variant="body">hamburgefons (body)</Text>
+        <Text variant="legalNote">hamburgefons (legalNote)</Text>
+        <Text variant="caption">hamburgefons (caption)</Text>
       </Stack>
     );
   },

--- a/packages/web-ui/src/Text/Text.stories.tsx
+++ b/packages/web-ui/src/Text/Text.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Stack from '@mui/material/Stack';
 import { Text } from './Text';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
+import { Box } from '../Box';
 
 const meta: Meta<typeof Text> = {
   title: 'Web UI / Components / Text',
@@ -90,6 +91,30 @@ export const TextVariants: Story = {
         <Text variant="body">hamburgefons (body)</Text>
         <Text variant="legalNote">hamburgefons (legalNote)</Text>
         <Text variant="caption">hamburgefons (caption)</Text>
+      </Stack>
+    );
+  },
+};
+
+export const TextColour: Story = {
+  name: 'Contextual Colour',
+  render: () => {
+    return (
+      <Stack>
+        <Box padding={2}>
+          <Text variant="subtitle">text</Text>
+        </Box>
+        <Box padding={2} backgroundColor={colorsCommon.brandPrimaryPurple}>
+          <Text variant="subtitle">text on brandPrimaryPurple background</Text>
+        </Box>
+        <Box padding={2} backgroundColor={colorsCommon.brandMidnight}>
+          <Text variant="subtitle">text on brandMidnight background</Text>
+        </Box>
+        <Box padding={2} backgroundColor={colorsCommon.brandMidnight}>
+          <Text variant="subtitle" color={colorsCommon.brandPink}>
+            text on brandMidnight background with custom color
+          </Text>
+        </Box>
       </Stack>
     );
   },

--- a/packages/web-ui/src/Text/Text.stories.tsx
+++ b/packages/web-ui/src/Text/Text.stories.tsx
@@ -1,9 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Stack from '@mui/material/Stack';
-import { Text, TextProps, textVariantMapping } from './Text';
+import { Text } from './Text';
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
-
-const variants = Object.keys(textVariantMapping);
 
 const meta: Meta<typeof Text> = {
   title: 'Web UI / Components / Text',
@@ -13,14 +11,16 @@ const meta: Meta<typeof Text> = {
 export default meta;
 type Story = StoryObj<typeof Text>;
 
+const sizes = ['lg', 'md', 'sm', 'xs'] as const;
+
 export const KitchenSink: Story = {
   parameters: { controls: { hideNoControlsWarning: true } },
   render: () => {
     return (
-      <Stack spacing={4}>
-        {variants.map(v => (
-          <Text key={v} component="span" variant={v as TextProps['variant']}>
-            Hamburgefons
+      <Stack spacing={1}>
+        {sizes.map(size => (
+          <Text key={size} size={size}>
+            Text size {size}
           </Text>
         ))}
       </Stack>
@@ -49,8 +49,8 @@ export const Workshop: Story = {
         type: 'text',
       },
     },
-    variant: {
-      options: variants,
+    size: {
+      options: sizes,
       control: {
         type: 'radio',
       },
@@ -68,40 +68,28 @@ export const Workshop: Story = {
       },
     },
     bold: { control: { type: 'boolean' } },
-    gutterBottom: { control: { type: 'boolean' } },
-    paragraph: { control: { type: 'boolean' } },
+    align: { control: { type: 'text' } },
     noWrap: { control: { type: 'boolean' } },
   },
   args: {
     children: 'hamburgefons',
-    variant: 'body',
+    size: 'md',
     component: 'span',
     color: undefined,
     bold: false,
     textTransform: 'capitalize',
-    gutterBottom: false,
-    paragraph: false,
-    noWrap: false,
   },
 };
 
-export const TextVariants: Story = {
-  name: 'Variants',
+export const TextSizes: Story = {
+  name: 'Sizes',
   render: () => {
     return (
       <Stack spacing={1}>
-        <Text component="span" variant="subtitle">
-          subtitle
-        </Text>
-        <Text component="span" variant="body">
-          body
-        </Text>
-        <Text component="span" variant="legalNote">
-          legalNote
-        </Text>
-        <Text component="span" variant="caption">
-          caption
-        </Text>
+        <Text size="lg">hamburgefons (lg)</Text>
+        <Text size="md">hamburgefons (md)</Text>
+        <Text size="sm">hamburgefons (sm)</Text>
+        <Text size="xs">hamburgefons (xs)</Text>
       </Stack>
     );
   },

--- a/packages/web-ui/src/Text/Text.stories.tsx
+++ b/packages/web-ui/src/Text/Text.stories.tsx
@@ -20,7 +20,7 @@ export const KitchenSink: Story = {
       <Stack spacing={1}>
         {variants.map(variant => (
           <Text key={variant} variant={variant}>
-            Text variant {variant}
+            Text variant: {variant}
           </Text>
         ))}
       </Stack>

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -11,7 +11,8 @@ export type TextProps = {
    */
   variant?: 'subtitle' | 'body' | 'legalNote' | 'caption';
   /**
-   * Sets the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
+   * Sets the text color.
+   * It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
    * @default colorsCommon.brandMidnight
    */
   color?: string;

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -4,24 +4,24 @@ import { Box, BoxProps } from '../Box';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { pxToRem } from '../utils';
 
-export type TextProps = Pick<BoxProps, 'sx' | 'component' | 'children'> &
-  Pick<MuiTypographyProps, 'textTransform' | 'align' | 'noWrap'> & {
-    /**
-     * Applies the typography size styles.
-     * @default md
-     */
-    size?: 'lg' | 'md' | 'sm' | 'xs';
-    /**
-     * Set the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
-     * @default colorsCommon.brandMidnight
-     */
-    color?: string;
-    /**
-     * Set the font-weight to semibold.
-     * @default false
-     */
-    bold?: boolean;
-  };
+export type TextProps = {
+  /**
+   * Applies the text font styles.
+   * @default body
+   */
+  variant?: 'subtitle' | 'body' | 'legalNote' | 'caption';
+  /**
+   * Sets the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
+   * @default colorsCommon.brandMidnight
+   */
+  color?: string;
+  /**
+   * Set the font-weight to semibold.
+   * @default false
+   */
+  bold?: boolean;
+} & Pick<BoxProps, 'sx' | 'component' | 'children'> &
+  Pick<MuiTypographyProps, 'textTransform' | 'align' | 'noWrap'>;
 
 /**
  * Text renders the secondary UW font, Work Sans, to be used for body copy.
@@ -30,7 +30,7 @@ export const Text = ({
   color = colorsCommon.brandMidnight,
   bold = false,
   component = 'p',
-  size = 'md',
+  variant = 'body',
   align,
   noWrap,
   sx,
@@ -39,10 +39,10 @@ export const Text = ({
   const fontFamily = fonts.secondary;
   const fontWeight = bold ? fontWeights.secondary.semibold : undefined;
   const fontSizes = {
-    xs: pxToRem(12),
-    sm: pxToRem(14),
-    md: pxToRem(16),
-    lg: {
+    caption: pxToRem(12),
+    legalNote: pxToRem(14),
+    body: pxToRem(16),
+    subtitle: {
       mobile: pxToRem(18),
       desktop: pxToRem(20),
     },
@@ -60,9 +60,9 @@ export const Text = ({
       color={color}
       component={component}
       fontFamily={fontFamily}
-      fontSize={fontSizes[size]}
+      fontSize={fontSizes[variant]}
       fontWeight={fontWeight}
-      lineHeight={size === 'xs' ? 2 : 1.5}
+      lineHeight={variant === 'caption' ? 2 : 1.5}
       textAlign={align}
       sx={noWrap ? noWrapStyles : sx}
       {...props}

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -2,7 +2,7 @@ import { TypographyProps as MuiTypographyProps } from '@mui/material/Typography'
 import { fonts, fontWeights } from '../tokens';
 import { Box, BoxProps } from '../Box';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
-import { pxToRem } from '../utils';
+import { dataAttributes, pxToRem } from '../utils';
 
 export type TextProps = {
   /**
@@ -28,7 +28,7 @@ export type TextProps = {
  * Text renders the secondary UW font, Work Sans, to be used for body copy.
  */
 export const Text = ({
-  color = colorsCommon.brandMidnight,
+  color,
   bold = false,
   component = 'p',
   variant = 'body',
@@ -49,8 +49,19 @@ export const Text = ({
     },
   };
 
-  const noWrapStyles = {
+  const colorStyles = {
+    [`[data-${dataAttributes.bgcolorBrand}=true] &`]: {
+      color: color || colorsCommon.brandWhite,
+    },
+  };
+
+  const baseStyles = {
     ...sx,
+    ...colorStyles,
+  };
+
+  const noWrapStyles = {
+    ...baseStyles,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -58,14 +69,14 @@ export const Text = ({
 
   return (
     <Box
-      color={color}
+      color={color || colorsCommon.brandMidnight}
       component={component}
       fontFamily={fontFamily}
       fontSize={fontSizes[variant]}
       fontWeight={fontWeight}
       lineHeight={variant === 'caption' ? 2 : 1.5}
       textAlign={align}
-      sx={noWrap ? noWrapStyles : sx}
+      sx={noWrap ? noWrapStyles : baseStyles}
       {...props}
     />
   );

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -29,7 +29,7 @@ export type TextProps = Pick<BoxProps, 'sx' | 'component' | 'children'> &
 export const Text = ({
   color = colorsCommon.brandMidnight,
   bold = false,
-  component = 'span',
+  component = 'p',
   size = 'md',
   align,
   noWrap,

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -1,70 +1,73 @@
-import { forwardRef } from 'react';
-import MuiTypography, { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
-import { OverridableComponent } from '@mui/material/OverridableComponent';
-import type { OverrideProps } from '@mui/material/OverridableComponent';
-import type { SystemProps } from '../types';
-import { fontWeights } from '../tokens';
+import { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
+import { fonts, fontWeights } from '../tokens';
+import { Box, BoxProps } from '../Box';
+import { colorsCommon } from '@utilitywarehouse/colour-system';
+import { pxToRem } from '../utils';
 
-export type DefaultTextComponent = 'span';
-
-export const textVariantMapping: Record<string, string> = {
-  subtitle: 'p',
-  body: 'p',
-  legalNote: 'p',
-  caption: 'span',
-};
-
-export interface CustomTextProps {
-  /**
-   * Applies the theme typography styles.
-   * @default body
-   */
-  variant: 'subtitle' | 'body' | 'legalNote' | 'caption';
-  /**
-   * The component used for the root node. Either a string to use a HTML element or a component.
-   */
-  component: React.ElementType;
-  /**
-   * Set the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
-   * @default colorsCommon.brandMidnight
-   */
-  color?: string;
-  /**
-   * Set the font-weight to semibold.
-   * @default false
-   */
-  bold?: boolean;
-  /**
-   * Set the text-transform property on the component.
-   */
-  textTransform?: MuiTypographyProps['textTransform'];
-}
-
-export interface TextTypeMap<D extends React.ElementType = DefaultTextComponent, P = {}> {
-  props: CustomTextProps & Omit<MuiTypographyProps<D, P>, 'variant' | SystemProps>;
-  defaultComponent: D;
-}
-
-export type TextProps<D extends React.ElementType = DefaultTextComponent, P = {}> = OverrideProps<
-  TextTypeMap<D, P>,
-  D
->;
+export type TextProps = Pick<BoxProps, 'sx' | 'component' | 'children'> &
+  Pick<MuiTypographyProps, 'textTransform' | 'align' | 'noWrap'> & {
+    /**
+     * Applies the typography size styles.
+     * @default md
+     */
+    size?: 'lg' | 'md' | 'sm' | 'xs';
+    /**
+     * Set the text color. It is recommended to use the colours from the `@utilitywarehouse/colour-system` package.
+     * @default colorsCommon.brandMidnight
+     */
+    color?: string;
+    /**
+     * Set the font-weight to semibold.
+     * @default false
+     */
+    bold?: boolean;
+  };
 
 /**
  * Text renders the secondary UW font, Work Sans, to be used for body copy.
  */
-export const Text = forwardRef(function Text(
-  { color, variant = 'body', bold = false, ...props },
-  ref
-) {
+export const Text = ({
+  color = colorsCommon.brandMidnight,
+  bold = false,
+  component = 'span',
+  size = 'md',
+  align,
+  noWrap,
+  sx,
+  ...props
+}: TextProps) => {
+  const fontFamily = fonts.secondary;
+  const fontWeight = bold ? fontWeights.secondary.semibold : undefined;
+  const fontSizes = {
+    xs: pxToRem(12),
+    sm: pxToRem(14),
+    md: pxToRem(16),
+    lg: {
+      mobile: pxToRem(18),
+      desktop: pxToRem(20),
+    },
+  };
+
+  const noWrapStyles = {
+    ...sx,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+
   return (
-    <MuiTypography
-      ref={ref}
-      variantMapping={textVariantMapping}
-      variant={variant}
+    <Box
       color={color}
-      fontWeight={bold ? fontWeights.secondary.semibold : undefined}
+      component={component}
+      fontFamily={fontFamily}
+      fontSize={fontSizes[size]}
+      fontWeight={fontWeight}
+      lineHeight={size === 'xs' ? 2 : 1.5}
+      textAlign={align}
+      sx={noWrap ? noWrapStyles : sx}
       {...props}
     />
   );
-}) as OverridableComponent<TextTypeMap>;
+};
+
+Text.displayName = 'Text';

--- a/packages/web-ui/src/Text/index.ts
+++ b/packages/web-ui/src/Text/index.ts
@@ -1,2 +1,2 @@
-export { Text, textVariantMapping } from './Text';
-export type { DefaultTextComponent, CustomTextProps, TextTypeMap, TextProps } from './Text';
+export { Text } from './Text';
+export type { TextProps } from './Text';

--- a/packages/web-ui/src/TextLink/TextLink.stories.tsx
+++ b/packages/web-ui/src/TextLink/TextLink.stories.tsx
@@ -1,9 +1,11 @@
 import { TextLink } from './TextLink';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Backgrounds } from '../storybook-utils';
-import { Text, TextProps, textVariantMapping } from '../Text';
-import { headingVariantMapping } from '../Heading';
+import { Text, TextProps } from '../Text';
 import { Stack } from '../Stack';
+import { headingVariantMapping, textVariantMapping, Typography } from '../Typography/Typography';
+import { Box } from '../Box';
+import { colorsCommon } from '@utilitywarehouse/colour-system';
 
 const meta: Meta<typeof TextLink> = {
   title: 'Web UI / Components / TextLink',
@@ -19,9 +21,15 @@ const variants = [...textVariants, ...Object.keys(headingVariantMapping)];
 export const Workshop: Story = {
   render: args => {
     return (
-      <Backgrounds>
-        <TextLink href="#" {...args} />
-      </Backgrounds>
+      <Stack>
+        {[colorsCommon.brandWhite, colorsCommon.brandPrimaryPurple, colorsCommon.brandMidnight].map(
+          bg => (
+            <Box key={bg} backgroundColor={bg} display="flex" justifyContent="center" padding={4}>
+              <TextLink href="#" {...args} />
+            </Box>
+          )
+        )}
+      </Stack>
     );
   },
   argTypes: {
@@ -54,12 +62,42 @@ export const InlineTextLink: Story = {
   name: 'Inline TextLink',
   render: () => {
     return (
+      <Stack>
+        {[colorsCommon.brandWhite, colorsCommon.brandPrimaryPurple, colorsCommon.brandMidnight].map(
+          bg => (
+            <Box key={bg} backgroundColor={bg} display="flex" justifyContent="center" padding={4}>
+              <Stack spacing={2}>
+                {textVariants.map(v => (
+                  <Text component="span" variant={v as TextProps['variant']}>
+                    This is a <TextLink href="#">text link</TextLink>, wrapped in a {v} Text
+                    component.
+                  </Text>
+                ))}
+              </Stack>
+            </Box>
+          )
+        )}
+      </Stack>
+    );
+  },
+};
+
+export const TextLinkColor: Story = {
+  name: 'On legacy Background',
+  render: () => {
+    return (
       <Backgrounds>
-        <Stack spacing={2}>
+        <Stack spacing={4}>
           {textVariants.map(v => (
-            <Text component="span" variant={v as TextProps['variant']}>
-              This is a <TextLink href="#">text link</TextLink>, wrapped in a {v} Text component.
-            </Text>
+            <Stack spacing={1}>
+              <TextLink href="#" variant={v as TextProps['variant']}>
+                {v} text link
+              </TextLink>
+              <Typography component="span" variant={v as TextProps['variant']}>
+                This is a <TextLink href="#">text link</TextLink>, wrapped in a {v} Typography
+                component.
+              </Typography>
+            </Stack>
           ))}
         </Stack>
       </Backgrounds>

--- a/packages/web-ui/src/TextLink/TextLink.theme.ts
+++ b/packages/web-ui/src/TextLink/TextLink.theme.ts
@@ -3,7 +3,7 @@ import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 import { transitions } from '../tokens';
 import { dataAttributes } from '../utils';
 
-const { inverse, heading } = dataAttributes;
+const { inverse, bgcolorBrand, heading } = dataAttributes;
 
 export const textLinkThemeOverrides: Partial<Components> = {
   MuiLink: {
@@ -24,6 +24,10 @@ export const textLinkThemeOverrides: Partial<Components> = {
         [`&[data-${heading}=true]`]: {
           color: colorsCommon.brandPrimaryPurple,
         },
+        [`[data-${bgcolorBrand}=true] &`]: {
+          color: colorsCommon.brandWhite,
+        },
+        // TODO: remove when `Background` removed.
         [`[data-${inverse}=true] &`]: {
           color: colorsCommon.brandWhite,
         },

--- a/packages/web-ui/src/Typography/Typography.stories.tsx
+++ b/packages/web-ui/src/Typography/Typography.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
-import { headingVariantMapping } from '../Heading';
 import { Backgrounds } from '../storybook-utils';
-import { textVariantMapping, Typography } from './Typography';
+import { headingVariantMapping, textVariantMapping, Typography } from './Typography';
 
 const textVariants = Object.keys(textVariantMapping);
 const headingVariants = Object.keys(headingVariantMapping);
@@ -44,6 +43,7 @@ export const Workshop: Story = {
 
 export const LegacyVariants: Story = {
   name: 'Deprecated Legacy Variants',
+  parameters: { layout: 'fullscreen' },
   render: args => (
     <Backgrounds>
       <Typography {...args} />

--- a/packages/web-ui/src/Typography/Typography.stories.tsx
+++ b/packages/web-ui/src/Typography/Typography.stories.tsx
@@ -2,8 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { headingVariantMapping } from '../Heading';
 import { Backgrounds } from '../storybook-utils';
-import { textVariantMapping } from '../Text';
-import { Typography } from './Typography';
+import { textVariantMapping, Typography } from './Typography';
 
 const textVariants = Object.keys(textVariantMapping);
 const headingVariants = Object.keys(headingVariantMapping);

--- a/packages/web-ui/src/Typography/Typography.theme.ts
+++ b/packages/web-ui/src/Typography/Typography.theme.ts
@@ -2,7 +2,7 @@ import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 import { fonts, fontWeights } from '../tokens';
 import { dataAttributes, mediaQueries, pxToRem } from '../utils';
 
-const { legacy, secondary, inverse, success, error } = dataAttributes;
+const { legacy, primary, secondary, inverse, success, error } = dataAttributes;
 
 const baseTextStyles = {
   fontFamily: fonts.secondary,
@@ -11,6 +11,9 @@ const baseTextStyles = {
 };
 
 const legacyTextStyles = {
+  [`&[data-${legacy}=true][data-${primary}=true]`]: {
+    color: colorsCommon.brandMidnight,
+  },
   [`[data-${inverse}=true] &`]: {
     [`&[data-${legacy}=true]`]: {
       color: colorsCommon.brandWhite,
@@ -36,8 +39,14 @@ const baseHeadingStyles = {
 };
 
 const legacyHeadingStyles = {
+  [`&[data-${legacy}=true][data-${primary}=true]`]: {
+    color: colorsCommon.brandPrimaryPurple,
+  },
   [`&[data-${legacy}=true][data-${secondary}=true]`]: {
     color: colorsCommon.brandMidnight,
+  },
+  [`&[data-${legacy}=true][data-${error}=true]`]: {
+    color: colorsCommon.brandPrimaryPurple,
   },
   [`[data-${inverse}=true] &`]: {
     [`&[data-${legacy}=true]`]: {

--- a/packages/web-ui/src/Typography/Typography.tsx
+++ b/packages/web-ui/src/Typography/Typography.tsx
@@ -4,9 +4,16 @@ import { OverridableComponent } from '@mui/material/OverridableComponent';
 import type { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
 import type { OverrideProps } from '@mui/material/OverridableComponent';
 import { Heading, HeadingProps, headingVariantMapping } from '../Heading';
-import { Text, TextProps, textVariantMapping } from '../Text';
+import { Text, TextProps } from '../Text';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { dataAttributes } from '../utils';
+
+export const textVariantMapping: Record<string, string> = {
+  subtitle: 'p',
+  body: 'p',
+  legalNote: 'p',
+  caption: 'span',
+};
 
 export type DefaultTypographyComponent = 'p';
 

--- a/packages/web-ui/src/Typography/Typography.tsx
+++ b/packages/web-ui/src/Typography/Typography.tsx
@@ -62,10 +62,16 @@ export const Typography = forwardRef(function Typography(
           [`data-${dataAttributes[getLegacyColor(color)]}`]: true,
         }
       : {};
+
+    const variantSizeMapping: { [key: string]: TextProps['size'] } = {
+      caption: 'xs',
+      legalNote: 'sm',
+      body: 'md',
+      subtitle: 'lg',
+    };
     return (
       <Text
-        ref={ref}
-        variant={variant as TextProps['variant']}
+        size={variantSizeMapping[variant]}
         component={component || 'p'}
         {...props}
         {...dataAttributeProps}

--- a/packages/web-ui/src/Typography/Typography.tsx
+++ b/packages/web-ui/src/Typography/Typography.tsx
@@ -3,7 +3,7 @@ import MuiTypography from '@mui/material/Typography';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import type { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
 import type { OverrideProps } from '@mui/material/OverridableComponent';
-import { Heading, HeadingProps, headingVariantMapping } from '../Heading';
+import { Heading, HeadingProps } from '../Heading';
 import { Text, TextProps } from '../Text';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { dataAttributes } from '../utils';
@@ -13,6 +13,13 @@ export const textVariantMapping: Record<string, string> = {
   body: 'p',
   legalNote: 'p',
   caption: 'span',
+};
+export const headingVariantMapping: Record<string, string> = {
+  displayHeading: 'h1',
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
 };
 
 export type DefaultTypographyComponent = 'p';
@@ -55,56 +62,67 @@ export const Typography = forwardRef(function Typography(
     console.warn(
       'The Typography variant prop is deprecated, please use the Text component instead'
     );
-    const dataAttributeProps = isLegacyColor
-      ? {
-          [`data-${dataAttributes.legacy}`]: true,
-          // @ts-ignore
-          [`data-${dataAttributes[getLegacyColor(color)]}`]: true,
-        }
-      : {};
-
-    const variantSizeMapping: { [key: string]: TextProps['size'] } = {
-      caption: 'xs',
-      legalNote: 'sm',
-      body: 'md',
-      subtitle: 'lg',
-    };
-    return (
-      <Text
-        size={variantSizeMapping[variant]}
-        component={component || 'p'}
-        {...props}
-        {...dataAttributeProps}
-      />
-    );
   }
+  const dataAttributeProps = isLegacyColor
+    ? {
+        [`data-${dataAttributes.legacy}`]: true,
+        // @ts-ignore
+        [`data-${dataAttributes[getLegacyColor(color)]}`]: true,
+      }
+    : {};
+
+  //   const variantSizeMapping: { [key: string]: TextProps['size'] } = {
+  //     caption: 'xs',
+  //     legalNote: 'sm',
+  //     body: 'md',
+  //     subtitle: 'lg',
+  //   };
+  //   return (
+  //     <Text
+  //       size={variantSizeMapping[variant]}
+  //       component={component || 'p'}
+  //       {...props}
+  //       {...dataAttributeProps}
+  //     />
+  //   );
+  // }
   if (isLegacyHeadingVariant) {
     console.warn(
       'The Typography variant prop is deprecated, please use the Heading component instead'
     );
-    const dataAttributeProps = isLegacyColor
-      ? {
-          [`data-${dataAttributes.legacy}`]: true,
-          // @ts-ignore
-          [`data-${dataAttributes[getLegacyColor(color)]}`]: true,
-        }
-      : {};
-    return (
-      <Heading
-        ref={ref}
-        variant={variant as HeadingProps['variant']}
-        component={component || 'h2'}
-        {...props}
-        {...dataAttributeProps}
-      />
-    );
   }
+  //   const dataAttributeProps = isLegacyColor
+  //     ? {
+  //         [`data-${dataAttributes.legacy}`]: true,
+  //         // @ts-ignore
+  //         [`data-${dataAttributes[getLegacyColor(color)]}`]: true,
+  //       }
+  //     : {};
+  //   const variantSizeMapping: { [key: string]: HeadingProps['size'] } = {
+  //     h4: 'xs',
+  //     h3: 'sm',
+  //     h2: 'md',
+  //     h1: 'lg',
+  //     displayHeading: 'xl',
+  //   };
+  //   return (
+  //     <Heading
+  //       ref={ref}
+  //       size={variantSizeMapping[variant]}
+  //       component={component || 'h2'}
+  //       {...props}
+  //       {...dataAttributeProps}
+  //     />
+  //   );
+  // }
 
   return (
     <MuiTypography
       ref={ref}
       color={color || colorsCommon.brandMidnight}
       component={component || 'p'}
+      variant={variant}
+      {...dataAttributeProps}
       {...props}
     />
   );

--- a/packages/web-ui/src/Typography/Typography.tsx
+++ b/packages/web-ui/src/Typography/Typography.tsx
@@ -3,8 +3,6 @@ import MuiTypography from '@mui/material/Typography';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import type { TypographyProps as MuiTypographyProps } from '@mui/material/Typography';
 import type { OverrideProps } from '@mui/material/OverridableComponent';
-import { Heading, HeadingProps } from '../Heading';
-import { Text, TextProps } from '../Text';
 import { colorsCommon } from '@utilitywarehouse/colour-system';
 import { dataAttributes } from '../utils';
 

--- a/packages/web-ui/src/storybook-utils/Backgrounds.tsx
+++ b/packages/web-ui/src/storybook-utils/Backgrounds.tsx
@@ -11,7 +11,7 @@ const Backgrounds = (props: BackgroundsProps) => (
     {backgroundColors.map(bg => (
       <Background
         key={bg}
-        background={bg}
+        backgroundColor={bg}
         display="flex"
         justifyContent="center"
         padding={4}

--- a/packages/web-ui/src/theme/CssBaseline.theme.ts
+++ b/packages/web-ui/src/theme/CssBaseline.theme.ts
@@ -6,6 +6,11 @@ export const cssBaselineThemeOverrides: Components = {
   MuiCssBaseline: {
     styleOverrides: {
       /* https://github.com/hankchizljaw/modern-css-reset/issues/30 */
+      /* Remove default margin */
+      'body, h1, h2, h3, h4, p, figure, blockquote, dl, dd': {
+        margin: 0,
+      },
+      /* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
       "ul[role='list'], ol[role='list']": {
         margin: 0,
         padding: 0,

--- a/packages/web-ui/src/utils/color.ts
+++ b/packages/web-ui/src/utils/color.ts
@@ -1,0 +1,5 @@
+import { type BackgroundColor, inverseBackgroundColors } from '../types';
+
+export const isInverseBackgroundColor = (backgroundColor: BackgroundColor): boolean => {
+  return (inverseBackgroundColors as ReadonlyArray<string>).includes(backgroundColor);
+};

--- a/packages/web-ui/src/utils/data-attributes.ts
+++ b/packages/web-ui/src/utils/data-attributes.ts
@@ -1,0 +1,14 @@
+export const dataAttributes = {
+  legacy: 'legacy-cwui',
+  primary: 'primary',
+  secondary: 'secondary',
+  success: 'success',
+  error: 'error',
+  variant: 'variant',
+  size: 'size',
+  inverse: 'inverse-background',
+  disableCapitalizeFirstLetter: 'disable-capitalize-first-letter',
+  multiline: 'multiline',
+  heading: 'heading',
+  bgcolorBrand: 'bg-color-brand',
+};

--- a/packages/web-ui/src/utils/index.ts
+++ b/packages/web-ui/src/utils/index.ts
@@ -1,41 +1,5 @@
-import { breakpoints, spacingBase } from '../tokens';
-import { type BackgroundColor, inverseBackgroundColors } from '../types';
-
-export const px = (value: string | number): string => `${value}px`;
-
-// 16px is the default font-size used by browsers.
-export const htmlFontSize = 16; // px
-export const pxToRem = (size: number) => `${size / htmlFontSize}rem`;
-
-export const spacing = (multiplier: number) => multiplier * spacingBase;
-
-const unit = 'px';
-const mq = (breakpoint: number) => `@media (min-width:${breakpoint}${unit})`;
-export const mediaQueries = {
-  mobile: mq(breakpoints.mobile),
-  tablet: mq(breakpoints.tablet),
-  desktop: mq(breakpoints.desktop),
-};
-
-export const isInverseBackgroundColor = (backgroundColor: BackgroundColor): boolean => {
-  return (inverseBackgroundColors as ReadonlyArray<string>).includes(backgroundColor);
-};
-
-export const isHeadingVariant = (variant: string): boolean => {
-  const headingVariants = ['displayHeading', 'h1', 'h2', 'h3', 'h4'];
-  return headingVariants.includes(variant);
-};
-
-export const dataAttributes = {
-  legacy: 'legacy-cwui',
-  primary: 'primary',
-  secondary: 'secondary',
-  success: 'success',
-  error: 'error',
-  variant: 'variant',
-  size: 'size',
-  inverse: 'inverse-background',
-  disableCapitalizeFirstLetter: 'disable-capitalize-first-letter',
-  multiline: 'multiline',
-  heading: 'heading',
-};
+export { dataAttributes } from './data-attributes';
+export { htmlFontSize, pxToRem, isHeadingVariant } from './typography';
+export { mediaQueries } from './media-queries';
+export { isInverseBackgroundColor } from './color';
+export { px, spacing } from './utils';

--- a/packages/web-ui/src/utils/media-queries.ts
+++ b/packages/web-ui/src/utils/media-queries.ts
@@ -1,0 +1,9 @@
+import { breakpoints } from '../tokens';
+
+const unit = 'px';
+const mq = (breakpoint: number) => `@media (min-width:${breakpoint}${unit})`;
+export const mediaQueries = {
+  mobile: mq(breakpoints.mobile),
+  tablet: mq(breakpoints.tablet),
+  desktop: mq(breakpoints.desktop),
+};

--- a/packages/web-ui/src/utils/typography.ts
+++ b/packages/web-ui/src/utils/typography.ts
@@ -1,0 +1,9 @@
+
+// 16px is the default font-size used by browsers.
+export const htmlFontSize = 16; // px
+export const pxToRem = (size: number) => `${size / htmlFontSize}rem`;
+
+export const isHeadingVariant = (variant: string): boolean => {
+  const headingVariants = ['displayHeading', 'h1', 'h2', 'h3', 'h4'];
+  return headingVariants.includes(variant);
+};

--- a/packages/web-ui/src/utils/utils.ts
+++ b/packages/web-ui/src/utils/utils.ts
@@ -1,0 +1,5 @@
+import { spacingBase } from '../tokens';
+
+export const px = (value: string | number): string => `${value}px`;
+
+export const spacing = (multiplier: number) => multiplier * spacingBase;


### PR DESCRIPTION
This reinstates the contextual colours for the following components, when wrapped in a `Box` with `backgroundColor` set to either `colorsCommon.brandPrimaryPurple` or `colorsCommon.brandMidnight`:

- `Text`
- `Heading`
- `Button`
- `TextLink`

This also removes some typography props from the Text & Heading components, such as `gutterBottom` & `paragraph`.