### PR TITLE
Docs theme example update

### DIFF
--- a/packages/web-ui/docs/web-ui/guides/theme.mdx
+++ b/packages/web-ui/docs/web-ui/guides/theme.mdx
@@ -130,6 +130,16 @@ using the colours in this way:
 </Box>
 ```
 
+We recommend you follow the guidelines and import the `colour-system` instead:
+```tsx
+import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
+
+<Box padding={8} bgcolor={colorsCommon.brandPink}></Box>
+<Box padding={8} bgcolor={colors.apple400} color="colors.apple900">
+  Apple
+</Box>
+```
+
 ### Typography
 
 <details>

--- a/packages/web-ui/docs/web-ui/guides/theme.mdx
+++ b/packages/web-ui/docs/web-ui/guides/theme.mdx
@@ -135,7 +135,7 @@ We recommend you follow the guidelines and import the `colour-system` instead:
 import { colors, colorsCommon } from '@utilitywarehouse/colour-system';
 
 <Box padding={8} bgcolor={colorsCommon.brandPink}></Box>
-<Box padding={8} bgcolor={colors.apple400} color="colors.apple900">
+<Box padding={8} bgcolor={colors.apple400} color={colors.apple900}>
   Apple
 </Box>
 ```


### PR DESCRIPTION
Right now there's only an anti-pattern example. Adding another pattern-like one may be useful for someone who went straight to the `palette` section without reading the `guidelines`