### PR TITLE
Typography fixes

### DIFF
--- a/.changeset/loud-windows-pay.md
+++ b/.changeset/loud-windows-pay.md
@@ -1,0 +1,8 @@
+---
+'@utilitywarehouse/css-reset': patch
+---
+
+Remove the text-rendering setting, as setting text-rendering to `optimizeSpeed` removes kerning & ligatures, and so noticeably affects the typography visuals of the Aeonik font.
+
+- https://css-tricks.com/almanac/properties/t/text-rendering/
+- https://marco.org/2012/11/15/text-rendering-optimize-legibility

--- a/.changeset/loud-windows-pay.md
+++ b/.changeset/loud-windows-pay.md
@@ -1,8 +1,25 @@
 ---
 '@utilitywarehouse/css-reset': patch
+'@utilitywarehouse/web-ui': patch
 ---
 
-Remove the text-rendering setting, as setting text-rendering to `optimizeSpeed` removes kerning & ligatures, and so noticeably affects the typography visuals of the Aeonik font.
+# text-rendering
+
+Remove the text-rendering setting from css-reset, as setting text-rendering to
+`optimizeSpeed` removes kerning & ligatures, and so noticeably affects the
+typography visuals of the Aeonik font.
+We will set this specifically in Web UI, differently for text & heading
+components.
 
 - https://css-tricks.com/almanac/properties/t/text-rendering/
 - https://marco.org/2012/11/15/text-rendering-optimize-legibility
+
+# font-smoothing
+
+Setting to antialiased significantly changes the appearance of text, and is only
+really beneficial with light text on dark background, so we're removing it from
+the css-reset and moving it to the heading & text components in Web UI.
+
+- https://www.joshwcomeau.com/css/custom-css-reset/#four-font-smoothing-5
+- https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/
+

--- a/.changeset/loud-windows-pay.md
+++ b/.changeset/loud-windows-pay.md
@@ -5,21 +5,10 @@
 
 # text-rendering
 
-Remove the text-rendering setting from css-reset, as setting text-rendering to
-`optimizeSpeed` removes kerning & ligatures, and so noticeably affects the
-typography visuals of the Aeonik font.
-We will set this specifically in Web UI, differently for text & heading
-components.
+Setting text-rendering to `optimizeSpeed` removes kerning & ligatures, and so
+noticeably affects the typography visuals of the Aeonik font. Therefore we will
+set it to `optimizeLegibility` for all heading elements, and in the Web UI
+`Heading` component.
 
 - https://css-tricks.com/almanac/properties/t/text-rendering/
 - https://marco.org/2012/11/15/text-rendering-optimize-legibility
-
-# font-smoothing
-
-Setting to antialiased significantly changes the appearance of text, and is only
-really beneficial with light text on dark background, so we're removing it from
-the css-reset and moving it to the heading & text components in Web UI.
-
-- https://www.joshwcomeau.com/css/custom-css-reset/#four-font-smoothing-5
-- https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/
-

--- a/packages/css-reset/src/index.css
+++ b/packages/css-reset/src/index.css
@@ -26,8 +26,6 @@ html:focus-within {
 body {
   min-height: 100vh;
   line-height: 1.5;
-  -moz-osx-font-smoothing: grayscale; /* Firefox */
-  -webkit-font-smoothing: antialiased; /* WebKit  */
   -webkit-text-size-adjust: 100%; /** Prevent adjustments of font size after orientation changes in iOS. */
   font-family: 'Work Sans', Arial, sans-serif; /** TODO: replace this with a custom property when available **/
 }

--- a/packages/css-reset/src/index.css
+++ b/packages/css-reset/src/index.css
@@ -26,8 +26,21 @@ html:focus-within {
 body {
   min-height: 100vh;
   line-height: 1.5;
+  text-rendering: optimizeSpeed;
+  -moz-osx-font-smoothing: grayscale; /* Firefox */
+  -webkit-font-smoothing: antialiased; /* WebKit  */
   -webkit-text-size-adjust: 100%; /** Prevent adjustments of font size after orientation changes in iOS. */
   font-family: 'Work Sans', Arial, sans-serif; /** TODO: replace this with a custom property when available **/
+}
+
+/** Preserve the ligatures and kerning of the Aeonik typeface used for headings. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-rendering: optimizeLegibility;
 }
 
 /* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */

--- a/packages/css-reset/src/index.css
+++ b/packages/css-reset/src/index.css
@@ -40,6 +40,7 @@ h3,
 h4,
 h5,
 h6 {
+  font-family: Aeonik, Arial, sans-serif; /** TODO: replace this with a custom property when available **/
   text-rendering: optimizeLegibility;
 }
 

--- a/packages/css-reset/src/index.css
+++ b/packages/css-reset/src/index.css
@@ -26,7 +26,6 @@ html:focus-within {
 body {
   min-height: 100vh;
   line-height: 1.5;
-  text-rendering: optimizeSpeed;
   -moz-osx-font-smoothing: grayscale; /* Firefox */
   -webkit-font-smoothing: antialiased; /* WebKit  */
   -webkit-text-size-adjust: 100%; /** Prevent adjustments of font size after orientation changes in iOS. */

--- a/packages/web-ui/src/Heading/Heading.tsx
+++ b/packages/web-ui/src/Heading/Heading.tsx
@@ -72,7 +72,12 @@ const StyledHeading = styled('p', {
       fontFamily: fonts.primary,
       fontWeight: fontWeights.primary,
       color: color || colorsCommon.brandPrimaryPurple,
+      textRendering: 'optimizeLegibility',
       ...(isBrandBackground && { color: color || colorsCommon.brandWhite }),
+      ...(isBrandBackground && {
+        mozOsxFontSmoothing: 'grayscale' /* Firefox */,
+        webkitFontSmoothing: 'antialiased' /* WebKit  */,
+      }),
       ...(noWrap && {
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/web-ui/src/Heading/Heading.tsx
+++ b/packages/web-ui/src/Heading/Heading.tsx
@@ -72,12 +72,8 @@ const StyledHeading = styled('p', {
       fontFamily: fonts.primary,
       fontWeight: fontWeights.primary,
       color: color || colorsCommon.brandPrimaryPurple,
-      textRendering: 'optimizeLegibility',
+      textRendering: 'optimizeLegibility', // ensure we preserve the ligatures & kerning of the Aeonik typeface
       ...(isBrandBackground && { color: color || colorsCommon.brandWhite }),
-      ...(isBrandBackground && {
-        mozOsxFontSmoothing: 'grayscale' /* Firefox */,
-        webkitFontSmoothing: 'antialiased' /* WebKit  */,
-      }),
       ...(noWrap && {
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -77,7 +77,12 @@ const StyledText = styled('p', {
       fontWeight: fontWeights.secondary[bold ? 'semibold' : 'regular'],
       lineHeight: variant === 'caption' ? 2 : 1.5,
       color: color || colorsCommon.brandMidnight,
+      textRendering: 'optimizeSpeed',
       ...(isBrandBackground && { color: color || colorsCommon.brandWhite }),
+      ...(isBrandBackground && {
+        mozOsxFontSmoothing: 'grayscale' /* Firefox */,
+        webkitFontSmoothing: 'antialiased' /* WebKit  */,
+      }),
       ...(noWrap && {
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/web-ui/src/Text/Text.tsx
+++ b/packages/web-ui/src/Text/Text.tsx
@@ -77,12 +77,7 @@ const StyledText = styled('p', {
       fontWeight: fontWeights.secondary[bold ? 'semibold' : 'regular'],
       lineHeight: variant === 'caption' ? 2 : 1.5,
       color: color || colorsCommon.brandMidnight,
-      textRendering: 'optimizeSpeed',
       ...(isBrandBackground && { color: color || colorsCommon.brandWhite }),
-      ...(isBrandBackground && {
-        mozOsxFontSmoothing: 'grayscale' /* Firefox */,
-        webkitFontSmoothing: 'antialiased' /* WebKit  */,
-      }),
       ...(noWrap && {
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/web-ui/src/tokens/index.ts
+++ b/packages/web-ui/src/tokens/index.ts
@@ -13,7 +13,7 @@ export type Breakpoints = typeof breakpoints;
 
 export const fonts = {
   primary: 'Aeonik, Arial, sans-serif',
-  secondary: 'Work Sans, Arial, sans-serif',
+  secondary: "'Work Sans', Arial, sans-serif",
 };
 export type Fonts = typeof fonts;
 


### PR DESCRIPTION
# text-rendering

Setting text-rendering to `optimizeSpeed` removes kerning & ligatures, and so
noticeably affects the typography visuals of the Aeonik font. Therefore we will
set it to `optimizeLegibility` for all heading elements, and in the Web UI
`Heading` component.

- https://css-tricks.com/almanac/properties/t/text-rendering/
- https://marco.org/2012/11/15/text-rendering-optimize-legibility
