### PR TITLE
fix(no-ticket): fix radio tile shrink RWD

### DIFF
--- a/.changeset/unlucky-clouds-reply.md
+++ b/.changeset/unlucky-clouds-reply.md
@@ -1,0 +1,5 @@
+---
+"@utilitywarehouse/web-ui": patch
+---
+
+Fix `RadioTile` shrink RWD

--- a/packages/web-ui/src/RadioTile/RadioTile.tsx
+++ b/packages/web-ui/src/RadioTile/RadioTile.tsx
@@ -20,6 +20,7 @@ const componentClassName = getPrefixedName(displayName);
 const StyledRadio = styled('div')({
   height: 24,
   width: 24,
+  flexShrink: 0,
   backgroundColor: colorsCommon.brandWhite,
   borderRadius: '100%',
   border: '2px solid',


### PR DESCRIPTION
## Description
Prevent `RadioTile` radio indicator from shrinking:
\
\
<img src="https://github.com/utilitywarehouse/design-systems/assets/34599355/2ccfad69-2a6d-4756-9ca8-d4a40e4bc1b3" width="300px"/> <img src="https://github.com/utilitywarehouse/design-systems/assets/34599355/3c97f898-ce23-4209-b13a-a64539ae24c0" width="300px"/>

