### PR TITLE
fix: split spinner component for web support

### DIFF
--- a/.changeset/hungry-camels-boil.md
+++ b/.changeset/hungry-camels-boil.md
@@ -1,0 +1,5 @@
+---
+'@utilitywarehouse/native-ui': patch
+---
+
+fix: split spinner component for web support

--- a/packages/native-ui/package.json
+++ b/packages/native-ui/package.json
@@ -46,7 +46,7 @@
     "react": ">=16",
     "react-dom": ">=16",
     "react-native": ">=0.72",
-    "react-native-reanimated": "~3.6.2",
+    "react-native-reanimated": "3.x",
     "react-native-svg": ">=13.4.0",
     "react-native-web": ">=0.19"
   },

--- a/packages/native-ui/src/components/Spinner/Spinner.web.tsx
+++ b/packages/native-ui/src/components/Spinner/Spinner.web.tsx
@@ -3,7 +3,6 @@ import {
   useSharedValue,
   withTiming,
   useAnimatedProps,
-  useAnimatedStyle,
   Easing,
   withSequence,
   withRepeat,
@@ -68,16 +67,11 @@ const Spinner: React.FC<SpinnerProps> = ({ size = 'md', color }) => {
     };
   }, [progress]);
 
-  const animatedSvgStyle = useAnimatedStyle(
-    () => ({
-      transform: [
-        {
-          rotate: `${rotation.value}deg`,
-        },
-      ],
-    }),
-    [rotation]
-  );
+  const animatedSvgProps = useAnimatedProps(() => {
+    return {
+      rotation: rotation.value,
+    };
+  }, [progress]);
 
   return (
     <StyledSpinner size={size}>
@@ -85,7 +79,7 @@ const Spinner: React.FC<SpinnerProps> = ({ size = 'md', color }) => {
         width={width}
         height={width}
         viewBox={`0 0 ${DIAMETER} ${DIAMETER}`}
-        style={animatedSvgStyle}
+        animatedProps={animatedSvgProps}
       >
         <G origin={`${HALF_CIRCLE}, ${HALF_CIRCLE}`} rotation={-90}>
           <StyledCircle


### PR DESCRIPTION
Small fix to allow reanimated to work with all 3.x versions and still work on the web