### PR TITLE
Radio updates from working on Checkbox

### DIFF
--- a/.changeset/chatty-knives-reflect.md
+++ b/.changeset/chatty-knives-reflect.md
@@ -1,0 +1,10 @@
+---
+'@utilitywarehouse/web-ui': patch
+---
+
+Radio updates from working on Checkbox
+- improve shared Radio group props
+- fix `HelperText` font weight
+- prefer `styled` over `sx` internally
+- fix `Divider` import in docs
+- add `userSelect: 'none'` to Radio components

--- a/packages/web-ui/src/BaseRadioGroup/BaseRadioGroup.props.ts
+++ b/packages/web-ui/src/BaseRadioGroup/BaseRadioGroup.props.ts
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 import { type RadioGroupProps as RadixRadioGroupProps } from '@radix-ui/react-radio-group';
+import { BoxProps } from '../Box';
 
 export interface BaseRadioGroupProps extends Omit<RadixRadioGroupProps, 'dir'> {
   children: ReactNode;
@@ -35,4 +36,9 @@ export interface BaseRadioGroupProps extends Omit<RadixRadioGroupProps, 'dir'> {
    * Set whether to display the error message icon.
    */
   showErrorMessageIcon?: boolean;
+  /**
+   * Set the width of the RadioGroup children, separate to the width of the
+   * entire RadioGroup.
+   */
+  contentWidth?: BoxProps['width'];
 }

--- a/packages/web-ui/src/BaseRadioGroup/BaseRadioGroup.tsx
+++ b/packages/web-ui/src/BaseRadioGroup/BaseRadioGroup.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { forwardRef } from 'react';
-import { Box } from '../Box';
 import { Root } from '@radix-ui/react-radio-group';
 import { Fieldset } from '../Fieldset';
 import { FieldsetLegend } from '../FieldsetLegend';
@@ -8,6 +7,7 @@ import { HelperText } from '../HelperText';
 import { useIds } from '../hooks';
 import { PropsWithSx } from '../types';
 import { mergeIds } from '../utils';
+import { Flex } from '../Flex';
 import { BaseRadioGroupProps } from './BaseRadioGroup.props';
 import { BaseRadioGroupProvider } from './BaseRadioGroup.context';
 
@@ -65,25 +65,25 @@ export const BaseRadioGroup = forwardRef<HTMLDivElement, PropsWithSx<BaseRadioGr
               {label}
             </FieldsetLegend>
           ) : null}
-
-          <Box display="flex" gap={2} flexDirection={direction}>
-            {helperText ? (
-              <HelperText id={helperTextId} disabled={disabled} showIcon={showHelperTextIcon}>
-                {helperText}
+          <Flex direction="column" gap={helperTextPosition === 'top' ? 2 : 1}>
+            <Flex gap={2} direction={direction}>
+              {helperText ? (
+                <HelperText id={helperTextId} disabled={disabled} showIcon={showHelperTextIcon}>
+                  {helperText}
+                </HelperText>
+              ) : null}
+              <BaseRadioGroupProvider value={value}>{children}</BaseRadioGroupProvider>
+            </Flex>
+            {showErrorMessage ? (
+              <HelperText
+                validationStatus="invalid"
+                showIcon={showErrorMessageIcon}
+                id={errorMessageId}
+              >
+                {errorMessage}
               </HelperText>
             ) : null}
-            <BaseRadioGroupProvider value={value}>{children}</BaseRadioGroupProvider>
-          </Box>
-
-          {showErrorMessage ? (
-            <HelperText
-              validationStatus="invalid"
-              showIcon={showErrorMessageIcon}
-              id={errorMessageId}
-            >
-              {errorMessage}
-            </HelperText>
-          ) : null}
+          </Flex>
         </Fieldset>
       </Root>
     );

--- a/packages/web-ui/src/HelperText/HelperText.tsx
+++ b/packages/web-ui/src/HelperText/HelperText.tsx
@@ -28,7 +28,7 @@ const classSelectors = {
 const StyledElement = styled('span')({
   display: 'inline-flex',
   fontFamily: fonts.secondary,
-  weight: fontWeights.secondary.regular,
+  fontWeight: fontWeights.secondary.regular,
   fontSize: pxToRem(13),
   lineHeight: pxToRem(16),
   gap: spacing(1),

--- a/packages/web-ui/src/Radio/Radio.tsx
+++ b/packages/web-ui/src/Radio/Radio.tsx
@@ -88,11 +88,28 @@ const StyledRadioContainer = styled('div')({
   margin: -8,
 });
 
+// we do this so that the gap between the checkbox & label is clickable
+const StyledLabel = styled(Label)({
+  userSelect: 'none',
+  position: 'relative',
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    height: '100%',
+    width: '100%',
+    left: -8,
+  },
+});
+
+const StyledHelperText = styled(HelperText)({
+  userSelect: 'none',
+});
+
 /**
  * Radios can be used to choose between a set of more than two options.
  *
- * Radios should always be used with a `RadioGroup` to handle the state control and
- * layout.
+ * Radios should always be used with a `RadioGroup` or `RadioGridGroup` to
+ * handle the state control and layout.
  *
  * > This component does not need to be wrapped in a `ThemeProvider` and can be used standalone with other component libraries.
  */
@@ -135,25 +152,12 @@ export const Radio = React.forwardRef<HTMLButtonElement, PropsWithSx<RadioProps>
         </StyledRadioContainer>
         {showLabel ? (
           <Flex direction="column" gap={0.5}>
-            <Label
-              id={labelId}
-              htmlFor={id}
-              nested
-              // we do this so that the gap between the radio & label is clickable
-              sx={{
-                position: 'relative',
-                '&:after': {
-                  content: '""',
-                  position: 'absolute',
-                  height: '100%',
-                  width: '100%',
-                  left: -8,
-                },
-              }}
-            >
+            <StyledLabel id={labelId} htmlFor={id} nested>
               {label}
-            </Label>
-            {showHelperText ? <HelperText id={helperTextId}>{helperText}</HelperText> : null}
+            </StyledLabel>
+            {showHelperText ? (
+              <StyledHelperText id={helperTextId}>{helperText}</StyledHelperText>
+            ) : null}
           </Flex>
         ) : null}
       </StyledElement>

--- a/packages/web-ui/src/RadioGridGroup/RadioGridGroup.props.ts
+++ b/packages/web-ui/src/RadioGridGroup/RadioGridGroup.props.ts
@@ -1,7 +1,7 @@
 import { StackProps } from '../Stack';
-import { RadioGroupProps } from '../RadioGroup';
+import { BaseRadioGroupProps } from '../BaseRadioGroup';
 
-export interface RadioGridGroupProps extends Omit<RadioGroupProps, 'direction'> {
+export interface RadioGridGroupProps extends Omit<BaseRadioGroupProps, 'direction'> {
   /** Sets the number of columns to display the contents in. */
   columns?: StackProps['spacing'];
 }

--- a/packages/web-ui/src/RadioGridGroup/RadioGridGroup.stories.tsx
+++ b/packages/web-ui/src/RadioGridGroup/RadioGridGroup.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { RadioGridGroup } from './RadioGridGroup';
-import { Stack } from '../Stack';
 import { RadioTile } from '../RadioTile';
 
 const meta: Meta<typeof RadioGridGroup> = {
@@ -61,16 +60,14 @@ export const RadioGridWithRadioHelperText: Story = {
   name: 'With Radio HelperText',
   render: args => {
     return (
-      <Stack spacing={8}>
-        <RadioGridGroup {...args}>
-          <RadioTile value="1" label="One" helperText="One helper text" />
-          <RadioTile value="2" label="Two" helperText="Two helper text" />
-          <RadioTile value="3" label="Three" helperText="Three helper text" />
-          <RadioTile value="4" label="One" helperText="Four helper text" />
-          <RadioTile value="5" label="Two" helperText="Five helper text" />
-          <RadioTile value="6" label="Three" helperText="Six helper text" />
-        </RadioGridGroup>
-      </Stack>
+      <RadioGridGroup {...args}>
+        <RadioTile value="1" label="One" helperText="One helper text" />
+        <RadioTile value="2" label="Two" helperText="Two helper text" />
+        <RadioTile value="3" label="Three" helperText="Three helper text" />
+        <RadioTile value="4" label="One" helperText="Four helper text" />
+        <RadioTile value="5" label="Two" helperText="Five helper text" />
+        <RadioTile value="6" label="Three" helperText="Six helper text" />
+      </RadioGridGroup>
     );
   },
   args: {
@@ -82,7 +79,7 @@ export const RadioGridGroupResponsiveColumns: Story = {
   name: 'With Responsive Columns',
   render: args => {
     return (
-      <RadioGridGroup {...args} columns={{ mobile: 2, desktop: 1 }}>
+      <RadioGridGroup {...args}>
         <RadioTile value="1" label="One" />
         <RadioTile value="2" label="Two" />
         <RadioTile value="3" label="Three" />
@@ -94,5 +91,6 @@ export const RadioGridGroupResponsiveColumns: Story = {
   },
   args: {
     helperText: 'RadioGridGroup with Responsive Columns',
+    columns: { mobile: 1, tablet: 2, desktop: 3, wide: 6 },
   },
 };

--- a/packages/web-ui/src/RadioGroup/RadioGroup.docs.mdx
+++ b/packages/web-ui/src/RadioGroup/RadioGroup.docs.mdx
@@ -4,7 +4,7 @@ import * as RadioStories from '../Radio/Radio.stories';
 import { Stack } from '../Stack';
 import { Box } from '../Box';
 import { Text } from '../Text';
-import { Divider } from '@mui/material';
+import { Divider } from '../Divider';
 
 <Meta of={RadioGroupStories} />
 
@@ -32,6 +32,8 @@ import { Divider } from '@mui/material';
 ## Alternatives
 
 - [RadioGridGroup](?path=/docs/components-radiogridgroup--documentation) - For presenting radios in columns or a grid layout.
+- [CheckboxGroup](?path=/docs/components-checkboxgroup--documentation) - For multi-select.
+- [CheckboxGridGroup](?path=/docs/components-checkboxgridgroup--documentation) - For multi-select in columns or grid layout.
 
 ## Accessibility
 

--- a/packages/web-ui/src/RadioTile/RadioTile.tsx
+++ b/packages/web-ui/src/RadioTile/RadioTile.tsx
@@ -73,6 +73,9 @@ const StyledRadioItem = styled(Item)({
   },
 }) as React.FC<RadioGroupItemProps & React.RefAttributes<HTMLButtonElement>>;
 
+const StyledLabel = styled(Label)({ userSelect: 'none' });
+const StyledHelperText = styled(HelperText)({ userSelect: 'none' });
+
 /**
  * The `RadioTile` should be used within a `RadioGroup` component.
  *
@@ -106,16 +109,18 @@ export const RadioTile = React.forwardRef<HTMLButtonElement, PropsWithSx<RadioTi
         aria-describedby={showHelperText ? helperTextId : ariaDescribedby}
         aria-labelledby={ariaLabelledby || !!label ? labelId : undefined}
       >
-        <Flex component="label" gap={1}>
+        <Flex component="span" gap={1}>
           <StyledRadio>
             <StyledRadioIndicator />
           </StyledRadio>
           {showLabel ? (
             <Flex direction="column" gap={0.5}>
-              <Label component="span" id={labelId} htmlFor={id} nested>
+              <StyledLabel component="span" id={labelId} htmlFor={id} nested>
                 {label}
-              </Label>
-              {showHelperText ? <HelperText id={helperTextId}>{helperText}</HelperText> : null}
+              </StyledLabel>
+              {showHelperText ? (
+                <StyledHelperText id={helperTextId}>{helperText}</StyledHelperText>
+              ) : null}
             </Flex>
           ) : null}
         </Flex>

--- a/packages/web-ui/src/utils/columns.ts
+++ b/packages/web-ui/src/utils/columns.ts
@@ -11,8 +11,9 @@ export function getColumns(columns: StackProps['spacing']) {
   }
   if (typeof columns === 'object') {
     return Object.keys(breakpoints).reduce((acc: { [key: string]: string }, breakpoint: string) => {
-      if (columns[breakpoint] !== null) {
-        acc[breakpoint] = convert(columns[breakpoint] as string);
+      const breakpointValue = columns[breakpoint];
+      if (breakpointValue !== undefined && breakpointValue !== null) {
+        acc[breakpoint] = convert(breakpointValue as string);
       }
       return acc;
     }, {});


### PR DESCRIPTION
Radio updates from working on Checkbox
- improve shared Radio group props
- fix `HelperText` font weight
- prefer `styled` over `sx` internally
- fix `Divider` import in docs
- add `userSelect: 'none'` to Radio components