### PR TITLE
refactor(no-ticket): move className prop to Checkbox wrapper

### DIFF
--- a/.changeset/quiet-shoes-invite.md
+++ b/.changeset/quiet-shoes-invite.md
@@ -1,0 +1,5 @@
+---
+'@utilitywarehouse/web-ui': patch
+---
+
+Move Checkbox className to outer element

--- a/packages/web-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-ui/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import clsx from 'clsx';
+
 import type { CheckboxProps } from './Checkbox.props';
 
 import { BaseCheckbox } from '../BaseCheckbox';
@@ -67,14 +69,17 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, PropsWithSx<Checkbox
     const ariaDescribedby = context ? context['aria-describedby'] : '';
     const showHelperText = !hasGroupHelperText && !!helperText;
     const showLabel = !!label;
-    
+
     return (
-      <StyledFlex className={className} data-disabled={disabled ? '' : undefined} gap={1}>
+      <StyledFlex
+        className={clsx(componentClassName, className)}
+        data-disabled={disabled ? '' : undefined}
+        gap={1}
+      >
         <StyledBaseCheckbox
           ref={ref}
           {...props}
           id={id}
-          className={componentClassName}
           disabled={disabled}
           aria-describedby={showHelperText ? helperTextId : ariaDescribedby}
           aria-labelledby={ariaLabelledby || showLabel ? labelId : undefined}

--- a/packages/web-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/web-ui/src/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import clsx from 'clsx';
-
 import type { CheckboxProps } from './Checkbox.props';
 
 import { BaseCheckbox } from '../BaseCheckbox';
@@ -69,13 +67,14 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, PropsWithSx<Checkbox
     const ariaDescribedby = context ? context['aria-describedby'] : '';
     const showHelperText = !hasGroupHelperText && !!helperText;
     const showLabel = !!label;
+    
     return (
-      <StyledFlex data-disabled={disabled ? '' : undefined} gap={1}>
+      <StyledFlex className={className} data-disabled={disabled ? '' : undefined} gap={1}>
         <StyledBaseCheckbox
           ref={ref}
           {...props}
           id={id}
-          className={clsx(componentClassName, className)}
+          className={componentClassName}
           disabled={disabled}
           aria-describedby={showHelperText ? helperTextId : ariaDescribedby}
           aria-labelledby={ariaLabelledby || showLabel ? labelId : undefined}


### PR DESCRIPTION
## Description

Attaching className to the checkbox wrapper instead of just to the `checkbox` element would allow to easily style all elements of the checkbox component, such as `label`